### PR TITLE
Document SKILL.md drag-drop import in README

### DIFF
--- a/inline-visualizer-v2/README.md
+++ b/inline-visualizer-v2/README.md
@@ -128,6 +128,9 @@ The **tool** mounts the iframe wrapper, injects the design-system CSS/JS, and ta
 3. Name it exactly **`visualize`** (the tool calls `view_skill("visualize")` by this name)
 4. Paste. **Save**.
 
+> [!TIP]
+> Or drag `SKILL.md` straight into the import field on **Workspace → Skills** — Open WebUI reads the YAML frontmatter (`name: visualize`, `description: …`) and pre-fills the create form for you. Just click **Save**.
+
 ### 3. Attach to your model
 
 1. **Admin Panel → Settings → Models** → edit the model you want


### PR DESCRIPTION
Open WebUI's Skills import accepts .md files and parses YAML frontmatter to pre-fill the create form, so users can skip the copy-paste step for the skill half of the install.