### PR TITLE
Fix: inline visualizations not rendering under native tool calling (OWUI 0.10+)

### DIFF
--- a/inline-visualizer-v2/tool.py
+++ b/inline-visualizer-v2/tool.py
@@ -1849,8 +1849,7 @@ STREAMING_OBSERVER_SCRIPT = """
   // True when `s` ends with a non-empty prefix of START_MARK (>= '@@@').
   // Lets us hide the marker paragraph while it is still streaming in
   // char-by-char (e.g. "@@@V"), so the raw start marker never flashes
-  // before the full token matches. '@@@' is the reserved sentinel, so
-  // this does not false-positive on ordinary prose.
+  // before the full token matches.
   function endsWithPartialStart(s) {
     for (var k = Math.min(s.length, START_MARK.length); k >= 3; k--) {
       if (START_MARK.substr(0, k) === s.substr(s.length - k)) return true;
@@ -2914,14 +2913,9 @@ return (() => {
             f"the HTML source itself. Emit exactly ONE @@@VIZ-START/@@@VIZ-END pair "
             f"for this tool call."
         )
-        # Deliver the wrapper as a MESSAGE-LEVEL embed (an "embeds" event) so it
-        # renders inline under BOTH native (OWUI >= 0.10) and legacy tool
-        # calling. Under native tool calling the embeds attached to the
-        # per-tool-call result item are not painted by the 0.10.x frontend,
-        # whereas the message-level "embeds" channel is path-independent and
-        # always renders (it is the same channel legacy already uses). Fall back
-        # to the original HTMLResponse return when no event emitter is available
-        # (older Open WebUI / non-emitter contexts) to preserve prior behavior.
+        # Under native tool calling the embeds attached to the per-tool-call result item are not painted by the frontend,
+        # whereas the message-level "embeds" channel is path-independent and always renders (it is the same channel legacy already uses).
+        # Fall back to the original HTMLResponse return when no event emitter is available to preserve prior behavior.
         if __event_emitter__:
             await __event_emitter__(
                 {"type": "embeds", "data": {"embeds": [html]}}

--- a/inline-visualizer-v2/tool.py
+++ b/inline-visualizer-v2/tool.py
@@ -1,7 +1,7 @@
 """
 title: Inline Visualizer
 author: Classic298
-version: 2.1.2
+version: 2.1.3
 required_open_webui_version: 0.9.5
 description: Renders interactive HTML/SVG visualizations inline in chat. Requires "iframe Sandbox Allow Same Origin" to be enabled in Open WebUI Settings -> Interface. For design instructions, the model should call view_skill("visualize").
 """
@@ -13,7 +13,7 @@ from typing import Literal
 # version can be verified at runtime (search DevTools for
 # `data-iv-build` on <html>).  Bump on every protocol-level change
 # so stale cached iframes can be spotted immediately.
-_IV_BUILD = "2.1.0"
+_IV_BUILD = "2.1.1"
 
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
@@ -1846,6 +1846,18 @@ STREAMING_OBSERVER_SCRIPT = """
     return null;
   }
 
+  // True when `s` ends with a non-empty prefix of START_MARK (>= '@@@').
+  // Lets us hide the marker paragraph while it is still streaming in
+  // char-by-char (e.g. "@@@V"), so the raw start marker never flashes
+  // before the full token matches. '@@@' is the reserved sentinel, so
+  // this does not false-positive on ordinary prose.
+  function endsWithPartialStart(s) {
+    for (var k = Math.min(s.length, START_MARK.length); k >= 3; k--) {
+      if (START_MARK.substr(0, k) === s.substr(s.length - k)) return true;
+    }
+    return false;
+  }
+
   // allowWrap=false during streaming (wrapping a text node breaks
   // Svelte's tracked refs and stalls post-VIZ chunks), true on finalize.
   function hideMarkerRange(allowWrap) {
@@ -1908,7 +1920,9 @@ STREAMING_OBSERVER_SCRIPT = """
       var hadStartLocal = tv.indexOf(START_MARK) !== -1;
       var hadEndLocal = tv.indexOf(END_MARK) !== -1;
 
-      var hideThis = inside || hadStartLocal || hadEndLocal;
+      var hadPartialStart = !hadStartLocal && !hadEndLocal && endsWithPartialStart(tv);
+
+      var hideThis = inside || hadStartLocal || hadEndLocal || hadPartialStart;
 
       if (hideThis) {
         var block = nearestBlockAncestor(tn.parentNode, msg);
@@ -2805,7 +2819,8 @@ class Tools:
         self,
         title: str = "Visualization",
         __event_call__=None,
-    ) -> tuple:
+        __event_emitter__=None,
+    ):
         """
         What this tool does: visualize() mounts an iframe sandbox directly in the chat.
         After this tool is called, the assistant must stream exactly one HTML/SVG visualization fragment between the plain-text delimiters @@@VIZ-START and @@@VIZ-END.
@@ -2875,13 +2890,14 @@ return (() => {
             except Exception:
                 pass
 
+        html = _build_html(
+            self.valves.security_level,
+            title,
+            lang,
+            chime=self.valves.chime,
+        )
         response = HTMLResponse(
-            content=_build_html(
-                self.valves.security_level,
-                title,
-                lang,
-                chime=self.valves.chime,
-            ),
+            content=html,
             headers={"Content-Disposition": "inline"},
         )
         result_context = (
@@ -2898,4 +2914,17 @@ return (() => {
             f"the HTML source itself. Emit exactly ONE @@@VIZ-START/@@@VIZ-END pair "
             f"for this tool call."
         )
+        # Deliver the wrapper as a MESSAGE-LEVEL embed (an "embeds" event) so it
+        # renders inline under BOTH native (OWUI >= 0.10) and legacy tool
+        # calling. Under native tool calling the embeds attached to the
+        # per-tool-call result item are not painted by the 0.10.x frontend,
+        # whereas the message-level "embeds" channel is path-independent and
+        # always renders (it is the same channel legacy already uses). Fall back
+        # to the original HTMLResponse return when no event emitter is available
+        # (older Open WebUI / non-emitter contexts) to preserve prior behavior.
+        if __event_emitter__:
+            await __event_emitter__(
+                {"type": "embeds", "data": {"embeds": [html]}}
+            )
+            return result_context
         return response, result_context


### PR DESCRIPTION
## Problem
Since Open WebUI 0.10, an inline visualization does not render under **native** tool
calling: the assistant message shows the raw `@@@VIZ-START … @@@VIZ-END` markers
instead of the iframe. Under **legacy** tool calling it still renders correctly.

Repro (OWUI 0.10.x, a model using native tool calling): enable this tool, ask e.g.
*"visualize a bar chart of 3, 7, 5, 9"* → the model calls `visualize()`, but the
block stays as raw text and `document.querySelectorAll('iframe').length === 0`.

## Root cause (in Open WebUI core, not this tool)
`visualize()` returns an `HTMLResponse` (`Content-Disposition: inline`); OWUI extracts
it into `embeds`.
- **Legacy** delivers `embeds` via a **message-level `embeds` socket event** →
  `message.embeds` → rendered directly (no transform). Works.
- **Native** attaches `embeds` to the per-tool-call `function_call_output` item. The
  frontend stores it as a raw `JSON.stringify` attribute, then runs html-entities
  `decode()` on it **before** `JSON.parse`. The wrapper HTML legitimately contains
  literal `&amp;`/`&lt;`/`&quot;` (e.g. in its download-as-HTML escaping JS), so
  `decode()` turns `&quot;`→`"`, injecting a bare quote into the JSON → `JSON.parse`
  throws → the embeds array is empty → **0 iframes**. (The model still receives the
  "Embedded UI result is active" replacement, so it looks like it "worked".)

The proper fix ultimately belongs in the OWUI frontend (parse the raw JSON first, only
`decode()` as a fallback). This PR makes the tool render **today, on unmodified Open
WebUI**.

## Fix (tool-side only, no OWUI core change)
`visualize()` now also delivers the wrapper via the **message-level `embeds` event**
(`__event_emitter__({"type": "embeds", "data": {"embeds": [html]}})`) and returns the
guidance string. That channel is path-independent and renders under **both native and
legacy**. When no event emitter is available (older Open WebUI / non-emitter contexts)
it falls back to the original `HTMLResponse` return, preserving prior behavior.

Also included: **marker-flash hardening** — the streaming observer now hides a
*partially* streamed start marker (e.g. `@@@V`) so the raw start marker never briefly
flashes before the full `@@@VIZ-START` token matches. `@@@` is the reserved sentinel,
so this cannot false-positive on ordinary prose.

No visual/branding changes — neutral defaults and light/dark following are unchanged.

## Testing
- Compiles; the `srcdoc`-safety guard (`_assert_srcdoc_safe`) still passes.
- Verified the message-level embed mechanism renders inline on Open WebUI 0.10.2 under
  **native and legacy**, in **light and dark**, with no marker flash. A final check on
  a clean instance before merge is recommended.

## Notes
- Minimal diff: 2 changes + version bump (2.1.2 → 2.1.3).
- Optional/related: under native tool calling, the "call `view_skill` first" requirement
  can make some models skip `visualize()` entirely — orthogonal to this render fix, but
  worth a separate look if you observe it.
