### PR TITLE
Render the three choice valves as labelled dropdowns

### DIFF
--- a/interface-defaults/event.py
+++ b/interface-defaults/event.py
@@ -3,7 +3,7 @@ title: Interface Defaults
 author: Classic298
 author_url: https://github.com/Classic298
 funding_url: https://github.com/Classic298
-version: 1.1.1
+version: 1.1.2
 required_open_webui_version: 0.10.2
 description: Manage Settings > Interface defaults instance-wide from this function's Valves. Only settings you switch to Custom are managed; anything left on Default is never written, so users keep their own choice for it. New users are seeded automatically (subscribes to user.created, which fires for signup, OAuth, LDAP, SCIM and admin-created accounts). Two trigger toggles act as one-shot buttons: "Apply to all existing users" pushes your Custom settings to everyone (normally only needed once, right after install), and "Reset all users to factory" clears the interface settings this function manages from every user AND puts this config back to Default. Both only touch those interface settings; a user's system prompt, default model, audio and other preferences are preserved unchanged. Tick a trigger and Save; it unticks itself and runs in the background over the users in chunks. Booleans render as toggles, direction as a dropdown, text scale as a number. No custom UI, no monkey-patching, no startup hooks. Defaults below match Open WebUI's factory values.
 """
@@ -156,12 +156,33 @@ class Event:
             title="Message Queue", default=True, description="Enable message queue"
         )
         chatDirection: Literal["auto", "LTR", "RTL"] = Field(
-            title="Chat Direction", default="auto", description="Chat text direction"
+            title="Chat Direction",
+            default="auto",
+            description="Chat text direction",
+            json_schema_extra={
+                "input": {
+                    "type": "select",
+                    "options": [
+                        {"value": "auto", "label": "Auto (follow the interface language)"},
+                        {"value": "LTR", "label": "Left to Right"},
+                        {"value": "RTL", "label": "Right to Left"},
+                    ],
+                }
+            },
         )
         landingPageMode: Literal["", "chat"] = Field(
             title="Landing Page Mode",
             default="",
-            description="Landing page: '' = default, 'chat' = chat",
+            description="Which view users land on after opening Open WebUI",
+            json_schema_extra={
+                "input": {
+                    "type": "select",
+                    "options": [
+                        {"value": "", "label": "Default (home screen)"},
+                        {"value": "chat", "label": "Chat"},
+                    ],
+                }
+            },
         )
         chatBubble: bool = Field(
             title="Chat Bubble UI", default=True, description="Chat bubble UI"
@@ -344,7 +365,16 @@ class Event:
         defaultUploadContext: Literal["focused", "full"] = Field(
             title="Default File Upload Context",
             default="focused",
-            description="Attached files default to 'focused' retrieval or 'full' document content (0.11.0+)",
+            description="How attached files are sent to the model by default (0.11.0+)",
+            json_schema_extra={
+                "input": {
+                    "type": "select",
+                    "options": [
+                        {"value": "focused", "label": "Using Focused Retrieval"},
+                        {"value": "full", "label": "Using Entire Document"},
+                    ],
+                }
+            },
         )
         imageCompression: bool = Field(
             title="Image Compression",


### PR DESCRIPTION
The select input type takes a label per value, so the three choice settings now read as words instead of raw storage values: chat direction as Auto / Left to Right / Right to Left, landing page as Default (home screen) / Chat instead of an empty string, and the file upload context as Open WebUI's own "Using Focused Retrieval" / "Using Entire Document". The stored values are unchanged, so existing configurations keep working.

## Description

<!-- Brief description of what this PR does. -->

---

## Contributor License Agreement (REQUIRED)

By submitting this pull request, I agree to the following terms:

By submitting my contributions to this repository in any form, I grant Classic298 a perpetual, worldwide, irrevocable, royalty-free license, under copyright and patent, to use, modify, distribute, sublicense, and commercialize my work under any terms they choose, both now and in the future.

I represent that my contributions are my original work (or that I have sufficient rights to grant this license) and that I have the authority to enter into this agreement.

**_To the fullest extent permitted by law, my contributions are provided on an "as is" basis, with no warranties or guarantees of any kind, and I disclaim any liability for any issues or damages arising from their use or incorporation into the project, regardless of the type of legal claim._**

- [ ] I have read and agree to the Contributor License Agreement above
