### PR TITLE
inline-visualizer 2.2.1: survive citation-swallowed arrays, color pie…

### DIFF
--- a/inline-visualizer-v2/README.md
+++ b/inline-visualizer-v2/README.md
@@ -4,7 +4,7 @@
 
 **Turn any Open WebUI chat into a live canvas.** Ask for a dashboard, diagram, chart, interactive quiz, architecture map, periodic table, flowchart, data explorer, OUR SOLAR SYSTEM — anything you'd draw in a browser — and watch the model paint it straight into the conversation as it types. Clickable nodes that send follow-up prompts. Copy-buttons that do the right thing. Sliders, toggles, and tabs that remember their state across reloads. Light/dark theme out of the box. A full 9-ramp design system so every visual looks like it belongs.
 
-Interactive. Stateful. Themed. Localized into 46 languages. Renders as the stream arrives — no waiting, no static pop-in.
+Interactive. Stateful. Themed. Localized into 48 languages. Renders as the stream arrives — no waiting, no static pop-in.
 
 > [!TIP]
 > **🚀 [Jump to Setup](#setup)** — up and running in about a minute.
@@ -31,7 +31,7 @@ Legend: 🚫 feature not in that version · ⚡ present, v2 expands it · ✅ pr
 | **CDN library catalog in skill** | ⚡ Chart.js, D3.js examples | ✅ Chart.js, D3.js, Vega-Lite, **ECharts**, **Plotly**, **vis-network** (standalone bundle), **Tone.js / Wavesurfer** — each with a vetted CDN URL and "when to reach for it" guidance. Allowlisted in strict CSP out of the box. |
 | **Chart-type coverage in skill** | ⚡ Bar / line / doughnut / scatter | ✅ Adds stacked bars/areas, radar, KPI cards with sparklines, progress bars, ranking strips, KPI donuts, custom-shape charts (thermometers, batteries, fuel gauges), plus comparison cards, slider-driven explainers, tabs (with hidden-panel init guidance), step-through walkthroughs. |
 | **Stream-completion feedback** | 🚫 N/A — no stream. | ✅ Localized "Visualization ready" toast in the top-right + an optional soft chime. Fires only when a real stream was seen — reopening a finished chat stays quiet. The chime is off-switchable via the `chime` valve (off → chime code isn't shipped at all). |
-| **i18n surface** | ⚡ 1 string × 46 languages = 46 translations (download tooltip) | ✅ 5 strings × 46 languages = **230 translations** — download tooltip, loader label, "unavailable" notice, "Copied" toast, "Visualization ready" toast. Auto-detected from `<html data-iv-lang>`, `localStorage.locale`, and `navigator.language`. |
+| **i18n surface** | ⚡ 1 string × 47 languages = 47 translations (download tooltip) | ✅ 8 strings × 48 languages = **384 translations** — download tooltip, loader label, "unavailable" notice (title + body), "Copied" toast, "Visualization ready" toast, "Export failed" toast, "Visualization script error" toast. Auto-detected from `<html data-iv-lang>`, `localStorage.locale`, and `navigator.language`. |
 | **Mid-stream reconciler** | 🚫 N/A — the iframe is built once from a complete payload. | ✅ Custom safe-cut HTML parser flushes the longest valid prefix on each chunk. Incremental DOM reconciler only appends new nodes and **leaves script-populated containers alone** so `d3.select(...).append('svg')`, `new vis.Network(...)`, ECharts canvases, etc. survive the final paint pass. **Existing nodes never re-mount, animations never re-trigger, zero flicker.** |
 | **Per-tick efficiency** | 🚫 N/A | ✅ `msg.textContent` cached between ticks; unchanged → full pipeline (regex extract, DOM walk, reconciler) short-circuits to a string compare. Only one tick per real DOM mutation does real work. |
 | **Dynamic script injection** | 🚫 N/A — scripts come baked into the static srcdoc and are parsed by the browser normally. | ✅ External `<script src>` + inline scripts injected at finalize() are **serialized via a Promise chain**. Each link wrapped + `.catch`'d so a single bad script can't stall the rest. `Chart`, `d3`, `vega-embed` etc. are guaranteed defined before consumer code runs. |
@@ -53,12 +53,14 @@ Legend: 🚫 feature not in that version · ⚡ present, v2 expands it · ✅ pr
 The tool returns an empty wrapper. The model then emits HTML/SVG between `@@@VIZ-START` / `@@@VIZ-END` text markers in its response. An observer tails the parent chat's live DOM, extracts the growing block, and reconciles new nodes into the iframe in real time. You see cards, SVGs, and charts appear as the model writes them — not all at once when the message completes.
 
 ### 🌍 Built-in localization
-Auto-detects the user's language from `<html data-iv-lang>` (injected server-side), then from parent `localStorage.locale`, then `navigator.language`. 46 languages for:
+Auto-detects the user's language from `<html data-iv-lang>` (injected server-side), then from parent `localStorage.locale`, then `navigator.language`. 48 languages for:
 - Download button tooltip
 - "Rendering visualization…" loader label
-- "Streaming visualization unavailable" notice (shown if `allow-same-origin` is off)
+- "Streaming visualization unavailable" notice (title and body, shown if `allow-same-origin` is off)
 - "Copied" confirmation toast
 - "Visualization ready" done toast
+- "Export failed" toast
+- "Visualization script error" toast
 
 ### 🎨 Design system
 - **9 color ramps** — purple, teal, coral, pink, gray, blue, green, amber, red — each with fill / stroke / text variants that auto-swap for light/dark mode
@@ -248,7 +250,7 @@ Keys are prefixed with the assistant message id, so a chart in Chat A and a char
 ```
 purple · teal · coral · pink · gray · blue · green · amber · red
 ```
-Apply via CSS class on any `<g>` — child `<rect>`, `<circle>`, `<ellipse>` get the ramp's fill + stroke automatically, child `.th` / `.ts` get the ramp's text colors. Light/dark adaptation is automatic.
+Apply via CSS class on any `<g>` — child `<rect>`, `<circle>`, `<ellipse>` get the ramp's fill + stroke automatically, un-classed, un-filled child `<path>` / `<polygon>` (pie wedges, areas) get the ramp's saturated stroke color (an explicit `fill` attribute always wins), and child `.th` / `.ts` get the ramp's text colors. `currentColor` anywhere inside the group resolves to the ramp color, so classed marks can opt back in with `fill="currentColor"`. Light/dark adaptation is automatic.
 
 ```html
 <g class="node c-teal">
@@ -290,9 +292,9 @@ calls for it.
 
 ## 🌍 Localization
 
-The tool bakes `<html data-iv-lang="{detected}">` on the server (reads parent `localStorage.locale` via `__event_call__`). Client-side fallbacks chain through `parent.localStorage` and `navigator.language`. 46 languages covered: en, de, cs, hu, hr, pl, fr, nl, es, pt, it, ca, gl, eu, da, sv, no, fi, is, sk, sl, sr, bs, bg, mk, uk, ru, be, lt, lv, et, ro, el, sq, tr, ar, he, zh, ja, ko, vi, th, id, ms, hi, bn, sw.
+The tool bakes `<html data-iv-lang="{detected}">` on the server (reads parent `localStorage.locale` via `__event_call__`). Client-side fallbacks chain through `parent.localStorage` and `navigator.language`. 48 languages covered: en, de, cs, hu, hr, pl, fr, nl, es, pt, it, ca, gl, eu, da, sv, no, fi, is, sk, sl, sr, bs, bg, mk, uk, ru, be, lt, lv, et, ro, el, sq, tr, az, ar, he, zh, ja, ko, vi, th, id, ms, hi, bn, sw.
 
-Five strings translated per language. That's **230 translations shipping** in the tool.
+Eight strings translated per language. That's **384 translations shipping** in the tool.
 
 ---
 
@@ -302,7 +304,7 @@ Every visualization renders in a sandboxed iframe with a configurable Content Se
 
 | Level | Outbound requests | External images | URL param stripping | Use case |
 |-------|:-:|:-:|:-:|---|
-| **Offline** *(new in 2.2.0)* | ❌ | ❌ | ✅ | **Zero outgoing connections** — even the three script CDNs are blocked. Libraries can be self-hosted on your instance ([tutorial ↓](#-offline-mode--self-hosting-the-cdn-libraries)). |
+| **Offline** *(new in 2.2.0)* | ❌ | ❌ | ✅ | **Nothing leaves your instance** — even the three script CDNs are blocked. Libraries can be self-hosted on your instance ([tutorial ↓](#-offline-mode--self-hosting-the-cdn-libraries)). |
 | **Strict** (default) | ❌ | ❌ | ✅ | Max safety with CDN charts. All core features work normally. |
 | **Balanced** | ❌ | ✅ | — | Visualizations displaying external images (flags, logos). |
 | **None** | ✅ | ✅ | — | Visualizations fetching live API data from within the iframe. |
@@ -327,7 +329,7 @@ Loading a library from a CDN is a plain `GET` of a fixed public URL — zero dat
 When DevTools is open, the browser attempts to fetch `.map` files for loaded libraries from the same CDN. Strict blocks those via `connect-src 'none'` — you'll see lines like `Connecting to 'https://cdn.jsdelivr.net/npm/vega.min.js.map' violates CSP…` in the console. Those are DevTools-only noise (end users with DevTools closed never see them). We intentionally don't relax `connect-src` to fix this because that would reopen the exfil surface above for all users.
 
 > [!WARNING]
-> With `allow-same-origin` enabled (required for streaming), JavaScript in a visualization has reach into the parent Open WebUI page. That is a platform-level permission — the tool cannot narrow it further. If you need full isolation, disable same-origin: v2 degrades gracefully with a localized "streaming unavailable" notice, and you can fall back to the original inline-visualizer (static mode only) for that workflow.
+> With `allow-same-origin` enabled (required for streaming), JavaScript in a visualization has reach into the parent Open WebUI page. That is a platform-level permission — the tool cannot narrow it further. The tool's only network traffic of its own is one same-origin GET to your own instance's chats API (retried until the chat is saved): when an inline script in a rendered block fails to parse, it re-reads the raw message text via the parent frame — works at every security level and sends nothing anywhere else. If you need full isolation, disable same-origin: v2 degrades gracefully with a localized "streaming unavailable" notice, and you can fall back to the original inline-visualizer (static mode only) for that workflow.
 
 > [!NOTE]
 > Even in **None** mode, external API calls may still fail due to CORS — that's the remote server's policy, not ours.
@@ -336,7 +338,7 @@ When DevTools is open, the browser attempts to fetch `.map` files for loaded lib
 
 ## 🔌 Offline mode — self-hosting the CDN libraries
 
-*(new in v2.2.0)* The **Offline** security level guarantees the visualization iframe makes **zero outgoing connections**: no CDNs, no external images, fonts, or media — nothing leaves your Open WebUI host. It exists for air-gapped networks and privacy-hardened deployments.
+*(new in v2.2.0)* The **Offline** security level guarantees **nothing leaves your Open WebUI host**: no CDNs, no external images, fonts, or media. The only request the tool itself ever makes is the same-origin chats-API read described under [Security](#-security). It exists for air-gapped networks and privacy-hardened deployments.
 
 Two ways to use it:
 
@@ -437,6 +439,12 @@ The 30s window is deliberately much longer than any realistic inter-chunk stall.
 </details>
 
 <details>
+<summary><b>A "Visualization script error" toast appears</b></summary>
+
+An inline script in the visualization does not parse. The usual cause is not the model: Open WebUI's citation rendering can silently swallow single-line numeric array literals like `[21, 11, 4]` from the message, corrupting the source the plugin reads from the chat DOM. The plugin detects the broken script before running it and re-reads the raw message text from your instance's chats API, which fixes the corrupted case automatically. The toast only appears when that recovery also dead-ends: the model genuinely wrote invalid JavaScript, the chat is unsaved (temporary chat), or the message kept streaming past the ~90s retry window — in the last case a refresh fixes it, because the saved chat recovers on the first attempt. The exact parse error is in the browser console.
+</details>
+
+<details>
 <summary><b>Chart.js / D3 renders but nothing appears</b></summary>
 
 Chart.js needs `<div style="position: relative; height: Xpx;">` around its canvas and `maintainAspectRatio: false` in options. See **Library init** in SKILL.md.
@@ -509,6 +517,7 @@ The observer inside the iframe uses `parent.document` (via `allow-same-origin`) 
 |---|---|---|
 | `@@@VIZ-END` in source | instant | Model closed the block cleanly (the 99%+ case) |
 | 30s of source stability | 30s | User stopped generation, model forgot END, or network died |
+| Raw-source recovery | up to ~90s | An inline script failed to parse (chat renderer corrupted the DOM source); finalize waits on the raw message text from the chats API, instant on saved chats |
 
 The idle fallback is deliberately much longer than any realistic inter-chunk stall — Gemini 3.1 Pro's 200-token chunks with 3-6s gaps, proxy buffering under poor network (10-20s silent pauses), and occasional stalls on other models all fit comfortably inside. If a stream genuinely dies for 30s+, the visualization is already gone — finalizing on the partial content beats a loader frozen forever, and refreshing the chat re-finalizes instantly from the saved markdown (which has both markers).
 

--- a/inline-visualizer-v2/SKILL.md
+++ b/inline-visualizer-v2/SKILL.md
@@ -220,7 +220,7 @@ font-size. They track the theme automatically.
 | .node | Cursor-pointer + hover opacity on a <g> | Mark a <g> as clickable. Pair with onclick="sendPrompt(...)" so a user can drill into the topic. |
 | .arr | 1.5px stroke matching theme borders | Arrow lines and connectors. Combine with marker-end="url(#arrow)". |
 | .leader | 0.5px dashed guide line | Pulling a label to a part of an illustration when the label can't sit on top of it. |
-| .c-{ramp} | Sets fill/stroke + text colors on a whole <g> from one of the 9 color ramps | Color a node by category — apply .c-teal (etc.) to a <g> and every shape and text inside picks up the matching ramp. |
+| .c-{ramp} | Sets fill/stroke + text colors on a whole <g> from one of the 9 color ramps | Color a node by category — apply .c-teal (etc.) to a <g> and every shape and text inside picks up the matching ramp. Un-classed, un-filled <path>/<polygon> children (pie wedges, areas) take the ramp's series color; on a classed or filled mark, fill="currentColor" opts back in. |
 
 ### Sizing text inside boxes
 

--- a/inline-visualizer-v2/tool.py
+++ b/inline-visualizer-v2/tool.py
@@ -3,7 +3,7 @@ title: Inline Visualizer
 author: Classic298
 author_url: https://github.com/Classic298
 funding_url: https://github.com/Classic298
-version: 2.2.0
+version: 2.2.1
 required_open_webui_version: 0.10.2
 description: Renders interactive HTML/SVG visualizations inline in chat. Requires "iframe Sandbox Allow Same Origin" to be enabled in Open WebUI Settings -> Interface. For design instructions, the model should call view_skill("visualize").
 """
@@ -15,7 +15,7 @@ from typing import Literal
 # version can be verified at runtime (search DevTools for
 # `data-iv-build` on <html>).  Bump on every protocol-level change
 # so stale cached iframes can be spotted immediately.
-_IV_BUILD = "2.2.0"
+_IV_BUILD = "2.2.1"
 
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
@@ -210,23 +210,36 @@ SVG_CLASSES = """
 .leader { stroke: var(--color-text-tertiary); stroke-width: 0.5; stroke-dasharray: 3 2; fill: none; }
 
 /* --- Color ramp selectors (fill/stroke adapt via CSS vars) --- */
+/* color: on the group resolves currentColor marks to the series color.
+   path/polygon get the saturated stroke stop (pale fill stops sit behind
+   label text and are indistinguishable side by side in a pie); classed
+   or explicitly-filled marks keep their own styling. */
 .c-purple>rect,.c-purple>circle,.c-purple>ellipse{fill:var(--ramp-purple-fill);stroke:var(--ramp-purple-stroke);stroke-width:.5}
+g.c-purple{color:var(--ramp-purple-stroke)} .c-purple>path:not([class]):not([fill]),.c-purple>polygon:not([class]):not([fill]){fill:var(--ramp-purple-stroke)}
 .c-purple>.th{fill:var(--ramp-purple-th)!important} .c-purple>.ts{fill:var(--ramp-purple-ts)!important}
 .c-teal>rect,.c-teal>circle,.c-teal>ellipse{fill:var(--ramp-teal-fill);stroke:var(--ramp-teal-stroke);stroke-width:.5}
+g.c-teal{color:var(--ramp-teal-stroke)} .c-teal>path:not([class]):not([fill]),.c-teal>polygon:not([class]):not([fill]){fill:var(--ramp-teal-stroke)}
 .c-teal>.th{fill:var(--ramp-teal-th)!important} .c-teal>.ts{fill:var(--ramp-teal-ts)!important}
 .c-coral>rect,.c-coral>circle,.c-coral>ellipse{fill:var(--ramp-coral-fill);stroke:var(--ramp-coral-stroke);stroke-width:.5}
+g.c-coral{color:var(--ramp-coral-stroke)} .c-coral>path:not([class]):not([fill]),.c-coral>polygon:not([class]):not([fill]){fill:var(--ramp-coral-stroke)}
 .c-coral>.th{fill:var(--ramp-coral-th)!important} .c-coral>.ts{fill:var(--ramp-coral-ts)!important}
 .c-pink>rect,.c-pink>circle,.c-pink>ellipse{fill:var(--ramp-pink-fill);stroke:var(--ramp-pink-stroke);stroke-width:.5}
+g.c-pink{color:var(--ramp-pink-stroke)} .c-pink>path:not([class]):not([fill]),.c-pink>polygon:not([class]):not([fill]){fill:var(--ramp-pink-stroke)}
 .c-pink>.th{fill:var(--ramp-pink-th)!important} .c-pink>.ts{fill:var(--ramp-pink-ts)!important}
 .c-gray>rect,.c-gray>circle,.c-gray>ellipse{fill:var(--ramp-gray-fill);stroke:var(--ramp-gray-stroke);stroke-width:.5}
+g.c-gray{color:var(--ramp-gray-stroke)} .c-gray>path:not([class]):not([fill]),.c-gray>polygon:not([class]):not([fill]){fill:var(--ramp-gray-stroke)}
 .c-gray>.th{fill:var(--ramp-gray-th)!important} .c-gray>.ts{fill:var(--ramp-gray-ts)!important}
 .c-blue>rect,.c-blue>circle,.c-blue>ellipse{fill:var(--ramp-blue-fill);stroke:var(--ramp-blue-stroke);stroke-width:.5}
+g.c-blue{color:var(--ramp-blue-stroke)} .c-blue>path:not([class]):not([fill]),.c-blue>polygon:not([class]):not([fill]){fill:var(--ramp-blue-stroke)}
 .c-blue>.th{fill:var(--ramp-blue-th)!important} .c-blue>.ts{fill:var(--ramp-blue-ts)!important}
 .c-green>rect,.c-green>circle,.c-green>ellipse{fill:var(--ramp-green-fill);stroke:var(--ramp-green-stroke);stroke-width:.5}
+g.c-green{color:var(--ramp-green-stroke)} .c-green>path:not([class]):not([fill]),.c-green>polygon:not([class]):not([fill]){fill:var(--ramp-green-stroke)}
 .c-green>.th{fill:var(--ramp-green-th)!important} .c-green>.ts{fill:var(--ramp-green-ts)!important}
 .c-amber>rect,.c-amber>circle,.c-amber>ellipse{fill:var(--ramp-amber-fill);stroke:var(--ramp-amber-stroke);stroke-width:.5}
+g.c-amber{color:var(--ramp-amber-stroke)} .c-amber>path:not([class]):not([fill]),.c-amber>polygon:not([class]):not([fill]){fill:var(--ramp-amber-stroke)}
 .c-amber>.th{fill:var(--ramp-amber-th)!important} .c-amber>.ts{fill:var(--ramp-amber-ts)!important}
 .c-red>rect,.c-red>circle,.c-red>ellipse{fill:var(--ramp-red-fill);stroke:var(--ramp-red-stroke);stroke-width:.5}
+g.c-red{color:var(--ramp-red-stroke)} .c-red>path:not([class]):not([fill]),.c-red>polygon:not([class]):not([fill]){fill:var(--ramp-red-stroke)}
 .c-red>.th{fill:var(--ramp-red-th)!important} .c-red>.ts{fill:var(--ramp-red-ts)!important}
 """
 
@@ -1310,6 +1323,58 @@ var _ivExportErrStr = {
   hi: 'निर्यात विफल',
   bn: 'এক্সপোর্ট ব্যর্থ হয়েছে',
   sw: 'Imeshindwa kuhamisha'
+};
+
+// Inline script failed to parse and raw-source recovery dead-ended.
+var _ivScriptErrStr = {
+  en: 'Visualization script error',
+  de: 'Fehler im Visualisierungsskript',
+  cs: 'Chyba skriptu vizualizace',
+  hu: 'Vizualizációs szkripthiba',
+  hr: 'Greška skripte vizualizacije',
+  pl: 'Błąd skryptu wizualizacji',
+  fr: 'Erreur de script de visualisation',
+  nl: 'Fout in visualisatiescript',
+  es: 'Error del script de visualización',
+  pt: 'Erro no script de visualização',
+  it: 'Errore nello script di visualizzazione',
+  ca: 'Error de l’script de visualització',
+  gl: 'Erro no script de visualización',
+  eu: 'Bistaratze-scriptaren errorea',
+  da: 'Fejl i visualiseringsscript',
+  sv: 'Fel i visualiseringsskript',
+  no: 'Feil i visualiseringsskript',
+  fi: 'Visualisointiskriptin virhe',
+  is: 'Villa í skriftu sjónrænnar framsetningar',
+  sk: 'Chyba skriptu vizualizácie',
+  sl: 'Napaka skripte vizualizacije',
+  sr: 'Грешка скрипте визуализације',
+  bs: 'Greška skripte vizualizacije',
+  bg: 'Грешка в скрипта на визуализацията',
+  mk: 'Грешка во скриптата на визуализацијата',
+  uk: 'Помилка скрипту візуалізації',
+  ru: 'Ошибка скрипта визуализации',
+  be: 'Памылка скрыпта візуалізацыі',
+  lt: 'Vizualizacijos scenarijaus klaida',
+  lv: 'Vizualizācijas skripta kļūda',
+  et: 'Visualiseeringu skripti viga',
+  ro: 'Eroare de script al vizualizării',
+  el: 'Σφάλμα σεναρίου οπτικοποίησης',
+  sq: 'Gabim në skriptin e vizualizimit',
+  tr: 'Görselleştirme betiği hatası',
+  az: 'Vizuallaşdırma skripti xətası',
+  ar: 'خطأ في نص التصور البرمجي',
+  he: 'שגיאת סקריפט ההדמיה',
+  zh: '可视化脚本错误',
+  ja: 'ビジュアライゼーションスクリプトのエラー',
+  ko: '시각화 스크립트 오류',
+  vi: 'Lỗi tập lệnh trực quan hóa',
+  th: 'ข้อผิดพลาดของสคริปต์การแสดงภาพ',
+  id: 'Kesalahan skrip visualisasi',
+  ms: 'Ralat skrip visualisasi',
+  hi: 'विज़ुअलाइज़ेशन स्क्रिप्ट त्रुटि',
+  bn: 'ভিজ্যুয়ালাইজেশন স্ক্রিপ্ট ত্রুটি',
+  sw: 'Hitilafu ya hati ya taswira'
 };
 
 var _ivErrBodyStr = {
@@ -3115,9 +3180,141 @@ STREAMING_OBSERVER_SCRIPT = """
     }
   }
 
+  // ---- Raw-source recovery (issue #75) --------------------------------
+  // The chat DOM is a lossy source: Open WebUI's citation machinery
+  // swallows bare numeric arrays like [21, 11, 4] (tokenised into a
+  // source chip, or regex-stripped when the model's Citations
+  // capability is off), leaving code the model never wrote (data:,).
+  // When an inline script fails to parse, finalize from the raw message
+  // text via the chats API instead. Retries cover live streams: content
+  // is only persisted once the response completes.
+  var _ivRecovery = 'idle';  // idle | pending | done | failed
+
+  function _ivFetchRawContent(chatId, messageId, onDone) {
+    var token = null;
+    try { token = parent.localStorage.getItem('token'); } catch(e) {}
+    try {
+      // parent.fetch runs under the parent page's CSP, so this works
+      // even when the iframe's own connect-src is locked down.
+      parent.fetch('/api/v1/chats/' + encodeURIComponent(chatId), {
+        headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+      }).then(function(res) {
+        return res.ok ? res.json() : null;
+      }).then(function(data) {
+        var msg = data && data.chat && data.chat.history &&
+                  data.chat.history.messages && data.chat.history.messages[messageId];
+        onDone(msg && typeof msg.content === 'string' ? msg.content : null);
+      }, function() { onDone(null); });
+    } catch(e) { onDone(null); }
+  }
+
+  // This embed's block from raw message text. Fenced code is stripped
+  // first so a fenced example cannot shift the block ordinal. Only a
+  // closed block counts: an open-ended match means the save raced the
+  // stream.
+  function _ivBlockFromRaw(content) {
+    var text = content.replace(/```[\\s\\S]*?```/g, '');
+    var idx = determineIndex();
+    if (idx === null) idx = 0;
+    var match = _ivMatchBlock(_ivStripDetailRanges(text, true), idx);
+    if (match === null) match = _ivMatchBlock(_ivStripDetailRanges(text, false), idx);
+    if (!match || match[0].indexOf(END_MARK) === -1) return null;
+    return match[1];
+  }
+
+  // SyntaxError of the first inline classic script in `html` that fails
+  // to parse, else null. new Function is a parse check only (nothing
+  // runs); no CSP this tool emits blocks eval. Only a SyntaxError
+  // counts: anything else means we could not validate, not that the
+  // code is bad.
+  function _ivScriptParseError(html) {
+    var temp = document.createElement('div');
+    try { temp.innerHTML = html.replace(_ivStripDocTags, ''); } catch(e) { return null; }
+    var scripts = temp.querySelectorAll('script');
+    for (var i = 0; i < scripts.length; i++) {
+      var script = scripts[i];
+      if (script.getAttribute('src')) continue;
+      var scriptType = script.getAttribute('type') || '';
+      if (scriptType && scriptType.indexOf('javascript') === -1) continue;
+      try { new Function(script.textContent || ''); }
+      catch(err) { if (err && err.name === 'SyntaxError') return err; }
+    }
+    return null;
+  }
+
+  function _ivStartRecovery(domText, scriptError) {
+    var chatId = null, messageId = null, attempt = 0;
+    try {
+      var pathMatch = parent.location.pathname.match(/\\/c\\/([^\\/?#]+)/);
+      chatId = pathMatch ? pathMatch[1] : null;
+      var frame = window.frameElement;
+      var embedContainer = frame && frame.closest && frame.closest('[id*="-embeds-"]');
+      var idMatch = embedContainer && embedContainer.id.match(/^(.+)-embeds-\\d+$/);
+      if (idMatch) {
+        messageId = idMatch[1];
+      } else {
+        // The tool-response path mounts the iframe outside an embeds container.
+        var msgEl = frame && frame.closest && frame.closest('[id^="message-"]');
+        if (msgEl) messageId = msgEl.id.slice('message-'.length);
+      }
+    } catch(e) {}
+    // The pending preview was diffed from the corrupt text, and
+    // reconcile never rewrites attributes on existing elements: render
+    // the final text from scratch (safe, no script has run yet).
+    function finalizeFresh(text) {
+      try { renderArea.innerHTML = ''; } catch(e) {}
+      finalize(text);
+    }
+    function fail(rawText, err) {
+      if (finalized) return;
+      _ivRecovery = 'failed';  // finalize toasts the error on live streams
+      try { console.error('iv[script] failed to parse', err || scriptError); } catch(e) {}
+      finalizeFresh(rawText || domText);
+    }
+    function attemptOnce() {
+      if (finalized) return;
+      _ivFetchRawContent(chatId, messageId, function(content) {
+        if (finalized) return;
+        var raw = content && _ivBlockFromRaw(content);
+        if (_ivLooksRenderable(raw)) {
+          var rawScriptError = _ivScriptParseError(raw);
+          if (!rawScriptError) { _ivRecovery = 'done'; finalizeFresh(raw); return; }
+          fail(raw, rawScriptError);  // the model's own JS is bad; still render its authentic text
+          return;
+        }
+        setTimeout(attemptOnce, Math.min(1500 * ++attempt, 8000));
+      });
+    }
+    // Unsaved contexts (temporary chats, shared pages) can never
+    // recover; deferred so finalize is never re-entered synchronously.
+    if (!chatId || !messageId) { setTimeout(function() { fail(); }, 0); return; }
+    // Armed deadline, not a between-attempts check: a fetch that never
+    // settles must not strand the loader. Trailing prose can delay the
+    // save, hence the generous window.
+    setTimeout(function() { fail(); }, 90000);
+    attemptOnce();
+  }
+
   function finalize(fullText) {
     if (finalized) return;
     if (!_ivLooksRenderable(fullText)) return;  // never latch on a non-HTML decoy
+    if (_ivRecovery === 'pending') return;
+    // Recovery needs a closed block: a truncated stream (user stop, dead
+    // connection) has no END marker in the saved text either, so retrying
+    // could never succeed and would only delay this finalize.
+    if (_ivRecovery === 'idle' && isBlockClosed()) {
+      var scriptError = _ivScriptParseError(fullText);
+      if (scriptError) {
+        // Corrupt reconstruction (or bad model JS): keep the script-less
+        // preview up and try the raw text before executing anything.
+        _ivRecovery = 'pending';
+        renderSafeInto(fullText, false);
+        markAndAnimate(renderArea);
+        scheduleHeight();
+        _ivStartRecovery(fullText, scriptError);
+        return;
+      }
+    }
     finalized = true;
     // withScripts=true so the reconciler materializes script tags.
     renderSafeInto(fullText, true);
@@ -3143,14 +3340,14 @@ STREAMING_OBSERVER_SCRIPT = """
     scheduleHeight();
     setTimeout(scheduleHeight, 120);
     setTimeout(scheduleHeight, 400);
-    // Done announcement — only on live streams, not on rehydration.
+    // Done/failed announcement — only on live streams, not on rehydration.
     if (wasStreaming) {
+      var failed = _ivRecovery === 'failed';
       try {
-        var label = (typeof _ivDoneStr !== 'undefined' &&
-                     (_ivDoneStr[_ivLang] || _ivDoneStr.en)) || 'Visualization ready';
-        if (typeof toast === 'function') toast(label, 'success');
+        var table = failed ? _ivScriptErrStr : _ivDoneStr;
+        if (typeof toast === 'function') toast(table[_ivLang] || table.en, failed ? 'error' : 'success');
       } catch(e) {}
-      try { if (typeof playDoneSound === 'function') playDoneSound(); } catch(e) {}
+      try { if (!failed && typeof playDoneSound === 'function') playDoneSound(); } catch(e) {}
     }
   }
 
@@ -3642,7 +3839,7 @@ def _build_html(
 #              requests. Use only for visualizations that fetch live API
 #              data (CORS restrictions still apply).
 #
-#   OFFLINE  — Zero outgoing connections of any kind. Same as STRICT but
+#   OFFLINE  — Nothing leaves the Open WebUI host. Same as STRICT but
 #              the public CDN hosts are dropped from script-src and
 #              'self' is allowed instead, so chart libraries must be
 #              served by the Open WebUI instance itself (drop the pinned


### PR DESCRIPTION
… wedges

Fixes #74 and #75.

Open WebUI's citation machinery silently deletes single-line numeric arrays like [21, 11, 4] from rendered messages, so the source rebuilt from the chat DOM could contain code the model never wrote (data:,) and the injected script died with a SyntaxError while the iframe stayed empty. Inline scripts are now parse-checked before anything runs; on a SyntaxError the observer re-reads the authentic message text from the chats API via the parent frame and renders that instead, falling back to the old behavior (plus an error toast and console line instead of silence) only when the raw text is equally broken or unreachable. Live streams retry for about 90s since the chat is only saved once the response completes; syntactically valid corruption is not detected and truncated streams skip recovery and finalize as before.

Pie/donut wedges drawn as path or polygon inside c-* groups all rendered in the body text color because the ramp CSS only styled rect, circle and ellipse. Each ramp now sets color: on the group and fills un-classed, un-filled path/polygon children with its stroke stop; classed marks and explicit fills keep their own styling.